### PR TITLE
Fix for alias record types other than "weighted"

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -437,9 +437,12 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		rec.HealthCheckId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("weight"); ok {
+		rec.Weight = aws.Int64(int64(v.(int)))
+	}
+
 	if v, ok := d.GetOk("set_identifier"); ok {
 		rec.SetIdentifier = aws.String(v.(string))
-		rec.Weight = aws.Int64(int64(d.Get("weight").(int)))
 	}
 
 	if v, ok := d.GetOk("region"); ok {


### PR DESCRIPTION
Reverts a workaround from upstream that breaks latency- and geo-routed records.
